### PR TITLE
Update headerfix variable from doggo_sniff.py to replace tabs with sp…

### DIFF
--- a/bin/doggo_sniff.py
+++ b/bin/doggo_sniff.py
@@ -261,7 +261,7 @@ if os.WEXITSTATUS(os.system(taxdistro)) == 1:
 #There's nothing to redirect as a log here.
 print ('Fixing FASTA headers (removing problematic characters, reversing assembly and sequence accessions).')
 #Originally was using cp with the new extensions and in-place editing, but after testing, runtime is 1/3 with this command, plus slightly lower peak memory consumption.
-headerfix = str('mkdir ' + args.concatenation + '_faafixedheaders && cd ' + args.concatenation + '_faafixedheaders && for i in ../' + args.concatenation + '_seqtk/*.faaoriginal ; do perl -p -e \'s/\\(/ /g\' "$i" | perl -p -e \'s/\\)/ /g\' | perl -p -e \'s/\\;/ /g\' | perl -p -e \'s/\\:/ /g\' | perl -p -e \'s/\\,/ /g\' | perl -p -e \'s/>(.*?) (.*?) (.*)/>$2 $1 $3/g\' >> "$(basename $i .faaoriginal)".faafixedheaders ; done')
+headerfix = str('mkdir ' + args.concatenation + '_faafixedheaders && cd ' + args.concatenation + '_faafixedheaders && for i in ../' + args.concatenation + '_seqtk/*.faaoriginal ; do perl -p -e \'s/\\(/ /g\' "$i" | perl -p -e \'s/\\)/ /g\' | perl -p -e \'s/\\;/ /g\' | perl -p -e \'s/\\:/ /g\' | perl -p -e \'s/\\,/ /g\' | perl -p -e \'s/\t/ /g\' | perl -p -e \'s/>(.*?) (.*?) (.*)/>$2 $1 $3/g\' >> "$(basename $i .faaoriginal)".faafixedheaders ; done')
 if os.WEXITSTATUS(os.system(headerfix)) == 1:
     print('Error when fixing FASTA headers. Exiting.')
     sys.exit(1)


### PR DESCRIPTION
This PR fixes a problem introduced by seqtk version r82.

With version r82 of seqtk, the "seqtk" step of "doggo_sniff.py" adds a tab in the sequence headers when creating the ".faaoriginal" files, which later on causes an overestimation of the number of taxa in "_preconcatenation/taxa.names" (that expects a space as separator and not a tab) and makes it impossible for any genes to pass the "threshcheck" at the end of the "preconcatenation.sh" script. This ultimately prevents any sequences to be added to the ".concatenation" file.
I, personally, have had bad experiences with unexpected behaviour from seqtk, so I always prefer to use seqkit instead.

Replacing tabs with spaces at the "headerfix" step solves the issue.